### PR TITLE
Sanitization and tidy up of Dockerfile

### DIFF
--- a/docker-watermill-tutorial/Dockerfile
+++ b/docker-watermill-tutorial/Dockerfile
@@ -4,9 +4,23 @@ MAINTAINER Tiago F. Jesus, tiagojesus@medicina.ulisboa.pt
 
 # INSTALL DEPENDENCIES
 
-RUN apt-get update
-RUN apt-get -y install unzip gzip wget gcc g++ libtbb-dev bzip2 make zlib1g-dev sudo curl zsh
-RUN apt-get -y install git npm
+RUN apt-get update && apt-get install -y apt-transport-https 
+RUN apt-get update && apt-get -y install \
+    bzip2 \
+    curl \
+    g++ \
+    gcc \
+    git \
+    gzip \
+    libtbb-dev \
+    make \
+    npm \
+    sudo \
+    unzip \
+    wget \
+    zlib1g-dev \
+    zsh \
+&& rm -rf /var/lib/apt/lists/*
 
 # INSTALL node.js version 7
 RUN curl -sL https://deb.nodesource.com/setup_7.x | sudo -E bash -
@@ -14,58 +28,46 @@ RUN apt-get install -y nodejs
 
 ### BOWTIE2 INSTALL ###
 
-WORKDIR /bin/
+WORKDIR /tmp/
 RUN wget https://downloads.sourceforge.net/project/bowtie-bio/bowtie2/2.3.2/bowtie2-2.3.2-linux-x86_64.zip
 RUN unzip bowtie2-2.3.2-linux-x86_64.zip
-RUN rm -rf bowtie2-2.3.2-linux-x86_64.zip
-
-# ADD BOWTIE TO PATH
-ENV PATH="/bin/bowtie2-2.3.2:${PATH}"
+RUN mv bowtie2-2.3.2/bowtie2* /usr/bin/
+RUN rm -rf bowtie2-2.3.2-linux-x86_64.zip bowtie2-2.3.2
 
 ### BWA INSTALL ###
 
 RUN wget https://sourceforge.net/projects/bio-bwa/files/bwa-0.7.15.tar.bz2
-RUN tar jxf bwa-0.7.15.tar.bz2
-RUN rm -rf bwa-0.7.15.tar.bz2
-WORKDIR /bin/bwa-0.7.15/
-RUN make
-
-# ADD BWA TO PATH
-ENV PATH="/bin/bwa-0.7.15:${PATH}"
+RUN mkdir bwa && tar xf bwa-0.7.15.tar.bz2 -C bwa --strip-components=1
+WORKDIR /tmp/bwa/
+RUN make && mv bwa /usr/bin/
+WORKDIR /tmp/
+RUN rm -rf bwa-0.7.15.tar.bz2 bwa
 
 ### DOWNLOAD FASTQ-DUMP ###
 
-WORKDIR /bin/
 RUN wget https://ftp-trace.ncbi.nlm.nih.gov/sra/sdk/2.8.2-1/sratoolkit.2.8.2-1-ubuntu64.tar.gz
-
-# EXTRACT THE FOLDER
-RUN tar -zxvf sratoolkit.2.8.2-1-ubuntu64.tar.gz
-RUN rm -rf sratoolkit.2.8.2-1-ubuntu64.tar.gz
-
-# PUT STA-TOOLKIT IN PATH
-ENV PATH="/bin/sratoolkit.2.8.2-1-ubuntu64/bin:${PATH}"
-
+RUN mkdir sratoolkit && tar xf sratoolkit.2.8.2-1-ubuntu64.tar.gz -C sratoolkit --strip-components=1 && mv sratoolkit/bin/fastdump* /usr/bin/
+RUN rm -rf sratoolkit.2.8.2-1-ubuntu64.tar.gz sratoolkit
 
 ### INSTALL SAMTOOLS ###
 
 RUN wget https://sourceforge.net/projects/samtools/files/samtools/1.4.1/samtools-1.4.1.tar.bz2
-RUN tar jxf samtools-1.4.1.tar.bz2
-RUN rm -rf samtools-1.4.1.tar.bz2
-WORKDIR /bin/samtools-1.4.1/
+RUN mkdir samtools && tar jxf samtools-1.4.1.tar.bz2 -C samtools --strip-components=1
+WORKDIR /tmp/samtools/
 RUN ./configure --without-curses --disable-bz2 --disable-lzma
-RUN make
-ENV PATH="/bin/samtools-1.4.1:${PATH}"
-
+RUN make && mv samtools /usr/bin/
+WORKDIR /tmp/
+RUN rm -rf samtools-1.4.1.tar.bz2 samtools
 
 ### FINAL BLOCK ###
 
-WORKDIR /bin/
+WORKDIR /home/bionode
 
 # CLONE BIONODE-WATERMILL FROM GIT HUB
 RUN git clone https://github.com/bionode/bionode-watermill.git
 
 # CHANGE DIRECTORY TO BIONODE-WATERMILL
-WORKDIR /bin/bionode-watermill
+WORKDIR /home/bionode/bionode-watermill
 RUN npm install
 RUN npm install bionode-ncbi -g
 


### PR DESCRIPTION
Made some changes so that the Dockerfile better adheres the dockerfile best practices (https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/).

The setup of third party applications (bowtie2, bwa, etc) is no longer performed directly on /bin. Instead, temporary packages and compilations are done in /tmp/, the relevant binaries are moved to /usr/bin/ and all else is removed at the end.

Also changed final working directory to be under /home instead of /bin.